### PR TITLE
circleciによる自動デプロイ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,8 @@ jobs:
       - run:
           name: download jq
           command: |
-            wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 mv jq-linux64 jq
+            wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+            mv jq-linux64 jq
       - run:
           name: login
           command: |


### PR DESCRIPTION
以下を修正。
・mvコマンドをjqのインストールと同じ箇所に書いてしまっていた。